### PR TITLE
Bugfix/Add boto3 to requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 annotated-types==0.6.0
 anthropic==0.30.1
+boto3==1.36.3
 asyncio==3.4.3
 bandit==1.7.8
 colorama==0.4.6


### PR DESCRIPTION
## Description
Boto3 is missing from requirements.txt needed for Bedrock.

Fixes #
Adds boto3 to requirements.txt

## Type of Change
<!-- Mark with an 'x' what type of change this is -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code cleanup or refactor

## Testing
<!-- Describe the tests you ran to verify your changes -->
- [x] All existing tests pass
- [ ] Added new tests for the changes
<!-- Describe the test cases you added -->

## Checklist
- [x] My code follows the project's style guidelines
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the documentation accordingly
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Additional Notes
Unsure if there is any preference for a specific version of boto3 from the author the Bedrock functionality, but this version passes pytest.