### PR TITLE
Feature/enhance logging for block class

### DIFF
--- a/legion/blocks/decorators.py
+++ b/legion/blocks/decorators.py
@@ -1,10 +1,16 @@
 import inspect
+import logging
 from typing import List, Optional, Type
 
 from pydantic import BaseModel
+from rich import print as rprint
+from rich.console import Console
 
 from .base import BlockMetadata, FunctionalBlock
 
+# Set up rich console and logging
+console = Console()
+logger = logging.getLogger(__name__)
 
 def block(
     name: Optional[str] = None,
@@ -13,7 +19,8 @@ def block(
     output_schema: Optional[Type[BaseModel]] = None,
     version: str = "1.0",
     tags: Optional[List[str]] = None,
-    validate: bool = True
+    validate: bool = True,
+    debug: Optional[bool] = False
 ):
     """Decorator to create a functional block
 
@@ -28,7 +35,19 @@ def block(
         ...
 
     """
+
+    def _log_message(message: str, color: str = None) -> None:
+        """Internal method for consistent logging"""
+        if debug:
+            if color:
+                rprint(f"\n[{color}]{message}[/{color}]")
+            else:
+                rprint(f"\n{message}")
+
     def decorator(func):
+
+        _log_message(f"Decorating function {func.__name__}", color="bold blue")
+
         # Extract function signature
         inspect.signature(func)
 
@@ -36,6 +55,7 @@ def block(
         block_description = description
         if not block_description and func.__doc__:
             block_description = func.__doc__.split("\n")[0].strip()
+            _log_message("Block description not provided, using function docstring instead")
         block_description = block_description or f"Block: {func.__name__}"
 
         # Only create schemas if explicitly requested or if schemas are provided

--- a/legion/blocks/decorators.py
+++ b/legion/blocks/decorators.py
@@ -55,7 +55,7 @@ def block(
         block_description = description
         if not block_description and func.__doc__:
             block_description = func.__doc__.split("\n")[0].strip()
-            _log_message("Block description not provided, using function docstring instead")
+            _log_message("Block description not provided, using function docstring instead\n")
         block_description = block_description or f"Block: {func.__name__}"
 
         # Only create schemas if explicitly requested or if schemas are provided


### PR DESCRIPTION
## Description
This PR introduces visually enhanced logs while in debug mode for the Block class in alignment with the Agent class.

## Related Issue
This addresses issue #15 

## Fixes
Uses rich for printing with colors and sensible grouping in the terminal.


## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code cleanup or refactor

## Implementation Details
Implements the following -

* Uses rich printing in two files: legion/blocks/base.py and legion/blocks/decorators.py
* Both the files used to use logging.debug to print debug information into the terminal, following the standard set in parts of legion/agents/base.py, all logging statements have been modified to use rich printing.
To turn on the print statements inside the decorator, the debug flag is passed to it as a decorator arg.

'''
@block(
    input_schema=TextInput,
    output_schema=SentimentOutput,
    tags=["text", "sentiment", "nlp"],
    debug=True
)
'''
For the block, verbose flag is passed at the await function call stage.

word_count_result = await count_words(input_data, verbose=True)

## Testing
<!-- Describe the tests you ran to verify your changes -->
- [X] All existing tests pass
- [ ] Added new tests for the changes
<!-- Describe the test cases you added -->

## Documentation Changes
<!-- List any documentation changes or updates needed -->

## Checklist
- [ ] My code follows the project's style guidelines
- [X] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the documentation accordingly
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes

## Screenshots (if applicable)
### Before:
![image](https://github.com/user-attachments/assets/67c76544-676a-4895-a7e6-ac22c13b23dc)
### After (with verbose block, verbose=True):
![image](https://github.com/user-attachments/assets/ee8cdeb9-7806-485f-a73c-455b3b0f26cd)
### After (with block decorator set to debug=True):
![image](https://github.com/user-attachments/assets/6a665ca5-9b17-43a4-a613-04303095033e)

Note: other logging seen on screen can be attributed to the chain class.

## Additional Notes
Not sure what the reason of having two separate flags - verbose and debug but have kept it consistent with the way the code was written and the way that Agents logging was enhanced.